### PR TITLE
[#73]  API에 로그인한 멤버를 가지고 필요한 로직들을 추가

### DIFF
--- a/src/main/java/dynamicquad/agilehub/global/auth/util/MemberArgumentResolver.java
+++ b/src/main/java/dynamicquad/agilehub/global/auth/util/MemberArgumentResolver.java
@@ -3,6 +3,7 @@ package dynamicquad.agilehub.global.auth.util;
 import dynamicquad.agilehub.global.auth.model.Auth;
 import dynamicquad.agilehub.global.auth.model.SecurityMember;
 import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -15,7 +16,7 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType().equals(Member.class);
+        return parameter.hasParameterAnnotation(Auth.class) && parameter.getParameterType().equals(AuthMember.class);
     }
 
     @Override
@@ -24,6 +25,12 @@ public class MemberArgumentResolver implements HandlerMethodArgumentResolver {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         SecurityMember principal = (SecurityMember) authentication.getPrincipal();
-        return principal.getMember();
+        Member member = principal.getMember();
+
+        return AuthMember.builder()
+            .id(member.getId())
+            .name(member.getName())
+            .profileImageUrl(member.getProfileImageUrl())
+            .build();
     }
 }

--- a/src/main/java/dynamicquad/agilehub/global/header/status/ErrorStatus.java
+++ b/src/main/java/dynamicquad/agilehub/global/header/status/ErrorStatus.java
@@ -21,6 +21,7 @@ public enum ErrorStatus implements BaseStatus {
     MEMBER_ROLE_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER_4004", "사용자 ROLE이 존재하지 않습니다."),
     INVALID_ACCESS_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER_4006", "유효하지 않은 Access Token입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "MEMBER_4007", "유효하지 않은 Refresh Token입니다."),
+    MEMBER_NOT_ADMIN(HttpStatus.BAD_REQUEST, "MEMBER_4005", "권한이 없습니다."),
 
     // Project Error
     PROJECT_DUPLICATE(HttpStatus.BAD_REQUEST, "PROJECT_4001", "프로젝트 키가 중복됩니다."),

--- a/src/main/java/dynamicquad/agilehub/global/header/status/ErrorStatus.java
+++ b/src/main/java/dynamicquad/agilehub/global/header/status/ErrorStatus.java
@@ -53,6 +53,7 @@ public enum ErrorStatus implements BaseStatus {
 
     // COMMENT Error
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT_4001", "댓글을 찾을 수 없습니다."),
+    COMMENT_WRITER_MISS_MATCH(HttpStatus.BAD_REQUEST, "COMMENT_4002", "댓글 작성자가 아닙니다."),
 
     // Statics Error
     EPIC_STATISTIC_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "STATICS_500", "에픽 통계를 찾을 수 없습니다.");

--- a/src/main/java/dynamicquad/agilehub/issue/comment/CommentController.java
+++ b/src/main/java/dynamicquad/agilehub/issue/comment/CommentController.java
@@ -2,12 +2,14 @@ package dynamicquad.agilehub.issue.comment;
 
 import static dynamicquad.agilehub.issue.comment.request.CommentRequest.CommentCreateRequest;
 
+import dynamicquad.agilehub.global.auth.model.Auth;
 import dynamicquad.agilehub.global.header.CommonResponse;
 import dynamicquad.agilehub.global.header.status.SuccessStatus;
 import dynamicquad.agilehub.issue.comment.response.CommentResponse.CommentCreateResponse;
 import dynamicquad.agilehub.issue.comment.response.CommentResponse.CommentUpdateResponse;
 import dynamicquad.agilehub.issue.comment.service.CommentQueryService;
 import dynamicquad.agilehub.issue.comment.service.CommentService;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -41,13 +43,10 @@ public class CommentController {
     @PostMapping(value = "/projects/{key}/issues/{issueId}/comments")
     public CommonResponse<?> createComment(@Valid @RequestBody CommentCreateRequest request,
                                            @PathVariable("key") String key,
-                                           @PathVariable("issueId") Long issueId) {
+                                           @PathVariable("issueId") Long issueId,
+                                           @Auth AuthMember authMember) {
 
-        //TODO: 현재, 가짜 멤버 객체 1L로 설정한 상태이므로 추후에 제거하고 실제 멤버 객체를 받아오도록 수정 필요
-        //TODO: 가짜 멤버 객체
-        Long memberId = 1L;
-
-        CommentCreateResponse resp = commentService.createComment(key, issueId, memberId, request.getContent());
+        CommentCreateResponse resp = commentService.createComment(key, issueId, request.getContent(), authMember);
         return CommonResponse.of(SuccessStatus.CREATED, resp);
     }
 
@@ -64,12 +63,10 @@ public class CommentController {
     @DeleteMapping(value = "/projects/{key}/issues/{issueId}/comments/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable("key") String key,
                                            @PathVariable("issueId") Long issueId,
-                                           @PathVariable("commentId") Long commentId) {
+                                           @PathVariable("commentId") Long commentId,
+                                           @Auth AuthMember authMember) {
 
-        //TODO: 현재, 가짜 멤버 객체 1L로 설정한 상태이므로 추후에 제거하고 실제 멤버 객체를 받아오도록 수정 필요
-        Long memberId = 1L;
-
-        commentService.deleteComment(key, issueId, commentId, memberId);
+        commentService.deleteComment(key, issueId, commentId, authMember);
         return ResponseEntity.noContent().build();
     }
 
@@ -79,13 +76,11 @@ public class CommentController {
     public CommonResponse<?> updateComment(@PathVariable("key") String key,
                                            @PathVariable("issueId") Long issueId,
                                            @PathVariable("commentId") Long commentId,
-                                           @Valid @RequestBody CommentCreateRequest request) {
-
-        //TODO: 현재, 가짜 멤버 객체 1L로 설정한 상태이므로 추후에 제거하고 실제 멤버 객체를 받아오도록 수정 필요
-        Long memberId = 1L;
+                                           @Valid @RequestBody CommentCreateRequest request,
+                                           @Auth AuthMember authMember) {
 
         CommentUpdateResponse resp = commentService.updateComment(key, issueId, commentId,
-            request.getContent(), memberId);
+            request.getContent(), authMember);
         return CommonResponse.of(SuccessStatus.OK, resp);
     }
 }

--- a/src/main/java/dynamicquad/agilehub/issue/comment/response/CommentResponse.java
+++ b/src/main/java/dynamicquad/agilehub/issue/comment/response/CommentResponse.java
@@ -19,8 +19,6 @@ public class CommentResponse {
         private String writerName;
         private LocalDateTime createdAt;
 
-
-        // TODO: 코멘트에 작성한 멤버의 아이디와 이름을 추출 하고 있으니 확인 바람. 체크 필요 [ ]
         public static CommentCreateResponse fromEntity(Comment comment) {
             return CommentCreateResponse.builder()
                 .id(comment.getId())
@@ -44,7 +42,6 @@ public class CommentResponse {
         private String writerName;
         private LocalDateTime createdAt;
 
-        // TODO: 코멘트에 작성한 멤버의 아이디와 이름을 추출 하고 있으니 확인 바람. 체크 필요 [ ]
         public static CommentReadResponse fromEntity(Comment comment) {
             return CommentReadResponse.builder()
                 .id(comment.getId())
@@ -63,7 +60,7 @@ public class CommentResponse {
     public static class CommentUpdateResponse {
         private Long id;
         private String content;
-        
+
         public static CommentUpdateResponse fromEntity(Comment comment) {
             return CommentUpdateResponse.builder()
                 .id(comment.getId())

--- a/src/main/java/dynamicquad/agilehub/issue/comment/service/CommentService.java
+++ b/src/main/java/dynamicquad/agilehub/issue/comment/service/CommentService.java
@@ -9,9 +9,12 @@ import dynamicquad.agilehub.issue.comment.response.CommentResponse.CommentUpdate
 import dynamicquad.agilehub.issue.domain.Issue;
 import dynamicquad.agilehub.issue.service.IssueValidator;
 import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.member.repository.MemberRepository;
 import dynamicquad.agilehub.project.domain.Project;
+import dynamicquad.agilehub.project.service.MemberProjectService;
 import dynamicquad.agilehub.project.service.ProjectValidator;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,20 +26,22 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CommentService {
 
+
     private final MemberRepository memberRepository;
     private final CommentRepository commentRepository;
 
     private final ProjectValidator projectValidator;
     private final IssueValidator issueValidator;
+    private final MemberProjectService memberProjectService;
 
 
     @Transactional
-    public CommentCreateResponse createComment(String key, Long issueId, Long memberId, String content) {
+    public CommentCreateResponse createComment(String key, Long issueId, String content, AuthMember authMember) {
+        
+        validate(key, issueId, authMember);
+        Issue issue = issueValidator.findIssue(issueId);
 
-        Issue issue = validateIssueInProject(key, issueId);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
-        // TODO: 코멘트를 작성한 멤버의 아이디를 인자로 받고 memberRepository에서 해당 멤버를 찾아온다음 Comment에 등록함. 체크 필요 [ ]
-        Member writer = memberRepository.findById(memberId)
+        Member writer = memberRepository.findById(authMember.getId())
             .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Comment comment = Comment.builder()
@@ -49,35 +54,43 @@ public class CommentService {
     }
 
     @Transactional
-    public void deleteComment(String key, Long issueId, Long commentId, Long memberId) {
-        // TODO: 코멘트 삭제 시, 해당 코멘트를 작성한 멤버와 현재 로그인한 멤버가 같은지 확인 필요 [ ]
-        validateIssueInProject(key, issueId);
+    public void deleteComment(String key, Long issueId, Long commentId, AuthMember authMember) {
+
+        validate(key, issueId, authMember);
 
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+        validateMemberMatch(authMember, comment);
 
         commentRepository.delete(comment);
     }
 
+
     @Transactional
     public CommentUpdateResponse updateComment(String key, Long issueId, Long commentId, String content,
-                                               Long memberId) {
-        //TODO: 코멘트 수정 시, 해당 코멘트를 작성한 멤버와 현재 로그인한 멤버가 같은지 확인 필요 [ ]
-        validateIssueInProject(key, issueId);
+                                               AuthMember authMember) {
+
+        validate(key, issueId, authMember);
 
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+        validateMemberMatch(authMember, comment);
 
         comment.updateComment(content);
         return CommentUpdateResponse.fromEntity(comment);
     }
 
-    private Issue validateIssueInProject(String key, Long issueId) {
-        Project project = projectValidator.findProject(key);
-        Issue issue = issueValidator.findIssue(issueId);
-        issueValidator.validateIssueInProject(project.getId(), issueId);
+    private void validateMemberMatch(AuthMember authMember, Comment comment) {
+        Member writer = comment.getWriter();
+        if (!Objects.equals(writer.getId(), authMember.getId())) {
+            throw new GeneralException(ErrorStatus.COMMENT_WRITER_MISS_MATCH);
+        }
+    }
 
-        return issue;
+    private void validate(String key, Long issueId, AuthMember authMember) {
+        Project project = projectValidator.findProject(key);
+        memberProjectService.validateMemberInProject(authMember, project.getId());
+        issueValidator.validateIssueInProject(project.getId(), issueId);
     }
 
 }

--- a/src/main/java/dynamicquad/agilehub/issue/comment/service/CommentService.java
+++ b/src/main/java/dynamicquad/agilehub/issue/comment/service/CommentService.java
@@ -37,7 +37,7 @@ public class CommentService {
 
     @Transactional
     public CommentCreateResponse createComment(String key, Long issueId, String content, AuthMember authMember) {
-        
+
         validate(key, issueId, authMember);
         Issue issue = issueValidator.findIssue(issueId);
 
@@ -89,7 +89,7 @@ public class CommentService {
 
     private void validate(String key, Long issueId, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
         issueValidator.validateIssueInProject(project.getId(), issueId);
     }
 

--- a/src/main/java/dynamicquad/agilehub/issue/controller/IssueController.java
+++ b/src/main/java/dynamicquad/agilehub/issue/controller/IssueController.java
@@ -44,8 +44,9 @@ public class IssueController {
     @ApiResponse(responseCode = "201", description = "이슈 생성 성공")
     @PostMapping(value = "/projects/{key}/issues", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> createProjectIssue(@Valid @ModelAttribute IssueCreateRequest request,
-                                                @PathVariable("key") String key) {
-        Long issueId = issueService.createIssue(key, request);
+                                                @PathVariable("key") String key,
+                                                @Auth AuthMember authMember) {
+        Long issueId = issueService.createIssue(key, request, authMember);
 
         return ResponseEntity.created(URI.create("/projects/" + key + "/issues/" + issueId))
             .body(CommonResponse.of(SuccessStatus.CREATED, issueId));
@@ -69,9 +70,10 @@ public class IssueController {
     @ApiResponse(responseCode = "204", description = "이슈 수정 성공")
     @PutMapping(value = "/projects/{key}/issues/{issueId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> editProjectIssue(@Valid @ModelAttribute IssueEditRequest request,
-                                              @PathVariable("key") String key, @PathVariable("issueId") Long issueId) {
+                                              @PathVariable("key") String key, @PathVariable("issueId") Long issueId,
+                                              @Auth AuthMember authMember) {
 
-        issueService.updateIssue(key, issueId, request);
+        issueService.updateIssue(key, issueId, request, authMember);
         return ResponseEntity.noContent().build();
     }
 
@@ -80,9 +82,10 @@ public class IssueController {
     @ApiResponse(responseCode = "204", description = "이슈 삭제 성공")
     @DeleteMapping(value = "/projects/{key}/issues/{issueId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> deleteProjectIssue(@PathVariable("key") String key,
-                                                @PathVariable("issueId") Long issueId) {
+                                                @PathVariable("issueId") Long issueId,
+                                                @Auth AuthMember authMember) {
 
-        issueService.deleteIssue(key, issueId);
+        issueService.deleteIssue(key, issueId, authMember);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/dynamicquad/agilehub/issue/controller/IssueController.java
+++ b/src/main/java/dynamicquad/agilehub/issue/controller/IssueController.java
@@ -2,12 +2,14 @@ package dynamicquad.agilehub.issue.controller;
 
 import static dynamicquad.agilehub.issue.controller.request.IssueRequest.IssueEditRequest;
 
+import dynamicquad.agilehub.global.auth.model.Auth;
 import dynamicquad.agilehub.global.header.CommonResponse;
 import dynamicquad.agilehub.global.header.status.SuccessStatus;
 import dynamicquad.agilehub.issue.controller.request.IssueRequest.IssueCreateRequest;
 import dynamicquad.agilehub.issue.controller.response.IssueResponse.IssueReadResponseDto;
 import dynamicquad.agilehub.issue.service.IssueQueryService;
 import dynamicquad.agilehub.issue.service.IssueService;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -55,9 +57,10 @@ public class IssueController {
             @ApiResponse(responseCode = "200", description = "이슈 조회 성공", content = @Content(schema = @Schema(implementation = IssueReadResponseDto.class)))}
     )
     @GetMapping(value = "/projects/{key}/issues/{issueId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CommonResponse<?> getProjectIssue(@PathVariable("key") String key, @PathVariable("issueId") Long issueId) {
+    public CommonResponse<?> getProjectIssue(@PathVariable("key") String key, @PathVariable("issueId") Long issueId,
+                                             @Auth AuthMember authMember) {
 
-        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getIssue(key, issueId));
+        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getIssue(key, issueId, authMember));
     }
 
 

--- a/src/main/java/dynamicquad/agilehub/issue/controller/ProjectIssuesController.java
+++ b/src/main/java/dynamicquad/agilehub/issue/controller/ProjectIssuesController.java
@@ -1,5 +1,6 @@
 package dynamicquad.agilehub.issue.controller;
 
+import dynamicquad.agilehub.global.auth.model.Auth;
 import dynamicquad.agilehub.global.header.CommonResponse;
 import dynamicquad.agilehub.global.header.status.SuccessStatus;
 import dynamicquad.agilehub.issue.controller.response.EpicResponse;
@@ -7,6 +8,7 @@ import dynamicquad.agilehub.issue.controller.response.SimpleIssueResponse;
 import dynamicquad.agilehub.issue.controller.response.StoryResponse;
 import dynamicquad.agilehub.issue.controller.response.TaskResponse;
 import dynamicquad.agilehub.issue.service.IssueQueryService;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -30,9 +32,9 @@ public class ProjectIssuesController {
             @ApiResponse(responseCode = "200", description = "에픽과 통계정보 조회 성공", content = @Content(schema = @Schema(implementation = EpicResponse.class)))}
     )
     @GetMapping(value = "/projects/{key}/epics/stats", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CommonResponse<?> getProjectEpicsWithStats(@PathVariable("key") String key) {
+    public CommonResponse<?> getProjectEpicsWithStats(@PathVariable("key") String key, @Auth AuthMember authMember) {
 
-        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getEpicsWithStats(key));
+        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getEpicsWithStats(key, authMember));
     }
 
     @Operation(summary = "에픽에 속하는 스토리들 조회", description = "에픽 아이디를 부모이슈로 요청해서 스토리들만 가져오는 API",
@@ -40,9 +42,10 @@ public class ProjectIssuesController {
             @ApiResponse(responseCode = "200", description = "스토리 조회 성공", content = @Content(schema = @Schema(implementation = StoryResponse.class)))}
     )
     @GetMapping(value = "/projects/{key}/epics/{epicId}/stories", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CommonResponse<?> getEpicStories(@PathVariable("key") String key, @PathVariable("epicId") Long epicId) {
+    public CommonResponse<?> getEpicStories(@PathVariable("key") String key, @PathVariable("epicId") Long epicId,
+                                            @Auth AuthMember authMember) {
 
-        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getStoriesByEpic(key, epicId));
+        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getStoriesByEpic(key, epicId, authMember));
     }
 
     @Operation(summary = "스토리에 속하는 테스크들 조회", description = "스토리 아이디를 부모이슈로 요청해서 테스크들만 가져오는 API",
@@ -50,9 +53,10 @@ public class ProjectIssuesController {
             @ApiResponse(responseCode = "200", description = "테스크 조회 성공", content = @Content(schema = @Schema(implementation = TaskResponse.class)))}
     )
     @GetMapping(value = "/projects/{key}/stories/{storyId}/tasks", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CommonResponse<?> getStoryTasks(@PathVariable("key") String key, @PathVariable("storyId") Long storyId) {
+    public CommonResponse<?> getStoryTasks(@PathVariable("key") String key, @PathVariable("storyId") Long storyId,
+                                           @Auth AuthMember authMember) {
 
-        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getTasksByStory(key, storyId));
+        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getTasksByStory(key, storyId, authMember));
     }
 
 
@@ -61,9 +65,9 @@ public class ProjectIssuesController {
             @ApiResponse(responseCode = "200", description = "에픽 조회 성공", content = @Content(schema = @Schema(implementation = SimpleIssueResponse.class)))}
     )
     @GetMapping(value = "/projects/{key}/epics", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CommonResponse<?> getProjectEpics(@PathVariable("key") String key) {
+    public CommonResponse<?> getProjectEpics(@PathVariable("key") String key, @Auth AuthMember authMember) {
 
-        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getEpics(key));
+        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getEpics(key, authMember));
     }
 
     @Operation(summary = "프로젝트에 할당된 스토리 간단한 조회", description = "프로젝트에 할당된 스토리들을 간단하게 조회하는 API",
@@ -71,9 +75,9 @@ public class ProjectIssuesController {
             @ApiResponse(responseCode = "200", description = "스토리 조회 성공", content = @Content(schema = @Schema(implementation = SimpleIssueResponse.class)))}
     )
     @GetMapping(value = "/projects/{key}/stories", produces = MediaType.APPLICATION_JSON_VALUE)
-    public CommonResponse<?> getProjectStories(@PathVariable("key") String key) {
+    public CommonResponse<?> getProjectStories(@PathVariable("key") String key, @Auth AuthMember authMember) {
 
-        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getStories(key));
+        return CommonResponse.of(SuccessStatus.OK, issueQueryService.getStories(key, authMember));
     }
 
 }

--- a/src/main/java/dynamicquad/agilehub/issue/service/IssueQueryService.java
+++ b/src/main/java/dynamicquad/agilehub/issue/service/IssueQueryService.java
@@ -51,7 +51,7 @@ public class IssueQueryService {
 
     public IssueReadResponseDto getIssue(String key, Long issueId, AuthMember authMember) {
         Long projectId = projectValidator.findProjectId(key);
-        memberProjectService.validateMemberInProject(authMember, projectId);
+        memberProjectService.validateMemberInProject(authMember.getId(), projectId);
 
         Issue issue = issueValidator.findIssue(issueId);
         issueValidator.validateIssueInProject(projectId, issueId);
@@ -75,7 +75,7 @@ public class IssueQueryService {
 
     public List<EpicWithStatisticResponse> getEpicsWithStats(String key, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
 
         List<Epic> epicsByProject = epicRepository.findByProject(project);
         List<EpicResponse> epicResponses = getEpicResponses(epicsByProject, project);
@@ -86,7 +86,7 @@ public class IssueQueryService {
 
     public List<StoryResponse> getStoriesByEpic(String key, Long epicId, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
         List<Story> storiesByEpic = storyRepository.findStoriesByEpicId(epicId);
 
         return storiesByEpic.stream()
@@ -96,7 +96,7 @@ public class IssueQueryService {
 
     public List<TaskResponse> getTasksByStory(String key, Long storyId, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
         List<Task> tasksByStory = taskRepository.findByStoryId(storyId);
 
         return tasksByStory.stream()
@@ -106,7 +106,7 @@ public class IssueQueryService {
 
     public List<SimpleIssueResponse> getEpics(String key, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
         List<Epic> epicsByProject = epicRepository.findByProject(project);
 
         return epicsByProject.stream()
@@ -117,7 +117,7 @@ public class IssueQueryService {
 
     public List<SimpleIssueResponse> getStories(String key, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
         List<Story> storiesByProject = storyRepository.findByProject(project);
 
         return storiesByProject.stream()

--- a/src/main/java/dynamicquad/agilehub/issue/service/IssueQueryService.java
+++ b/src/main/java/dynamicquad/agilehub/issue/service/IssueQueryService.java
@@ -25,7 +25,9 @@ import dynamicquad.agilehub.issue.domain.task.TaskRepository;
 import dynamicquad.agilehub.issue.service.factory.IssueFactory;
 import dynamicquad.agilehub.issue.service.factory.IssueFactoryProvider;
 import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.domain.Project;
+import dynamicquad.agilehub.project.service.MemberProjectService;
 import dynamicquad.agilehub.project.service.ProjectValidator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -40,15 +42,17 @@ public class IssueQueryService {
     private final IssueFactoryProvider issueFactoryProvider;
     private final IssueValidator issueValidator;
     private final ProjectValidator projectValidator;
+    private final MemberProjectService memberProjectService;
 
     private final EpicRepository epicRepository;
     private final StoryRepository storyRepository;
     private final TaskRepository taskRepository;
 
 
-    public IssueReadResponseDto getIssue(String key, Long issueId) {
+    public IssueReadResponseDto getIssue(String key, Long issueId, AuthMember authMember) {
         Long projectId = projectValidator.findProjectId(key);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
+        memberProjectService.validateMemberInProject(authMember, projectId);
+
         Issue issue = issueValidator.findIssue(issueId);
         issueValidator.validateIssueInProject(projectId, issueId);
 
@@ -69,9 +73,9 @@ public class IssueQueryService {
     }
 
 
-    public List<EpicWithStatisticResponse> getEpicsWithStats(String key) {
+    public List<EpicWithStatisticResponse> getEpicsWithStats(String key, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
+        memberProjectService.validateMemberInProject(authMember, project.getId());
 
         List<Epic> epicsByProject = epicRepository.findByProject(project);
         List<EpicResponse> epicResponses = getEpicResponses(epicsByProject, project);
@@ -80,9 +84,9 @@ public class IssueQueryService {
         return getEpicWithStatisticResponses(epicResponses, epicStatics);
     }
 
-    public List<StoryResponse> getStoriesByEpic(String key, Long epicId) {
+    public List<StoryResponse> getStoriesByEpic(String key, Long epicId, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
+        memberProjectService.validateMemberInProject(authMember, project.getId());
         List<Story> storiesByEpic = storyRepository.findStoriesByEpicId(epicId);
 
         return storiesByEpic.stream()
@@ -90,9 +94,9 @@ public class IssueQueryService {
             .toList();
     }
 
-    public List<TaskResponse> getTasksByStory(String key, Long storyId) {
+    public List<TaskResponse> getTasksByStory(String key, Long storyId, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
+        memberProjectService.validateMemberInProject(authMember, project.getId());
         List<Task> tasksByStory = taskRepository.findByStoryId(storyId);
 
         return tasksByStory.stream()
@@ -100,9 +104,9 @@ public class IssueQueryService {
             .toList();
     }
 
-    public List<SimpleIssueResponse> getEpics(String key) {
+    public List<SimpleIssueResponse> getEpics(String key, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
+        memberProjectService.validateMemberInProject(authMember, project.getId());
         List<Epic> epicsByProject = epicRepository.findByProject(project);
 
         return epicsByProject.stream()
@@ -111,9 +115,9 @@ public class IssueQueryService {
     }
 
 
-    public List<SimpleIssueResponse> getStories(String key) {
+    public List<SimpleIssueResponse> getStories(String key, AuthMember authMember) {
         Project project = projectValidator.findProject(key);
-        // TODO: 프로젝트에 속하는 멤버인지 확인하는 로직 필요 [ ]
+        memberProjectService.validateMemberInProject(authMember, project.getId());
         List<Story> storiesByProject = storyRepository.findByProject(project);
 
         return storiesByProject.stream()

--- a/src/main/java/dynamicquad/agilehub/issue/service/factory/EpicFactory.java
+++ b/src/main/java/dynamicquad/agilehub/issue/service/factory/EpicFactory.java
@@ -75,7 +75,7 @@ public class EpicFactory implements IssueFactory {
     @Transactional
     @Override
     public Long updateIssue(Issue issue, Project project, IssueEditRequest request) {
-        // TODO: 멤버 클래스에 이 로직을 따로 만들기 [x]
+
         Member assignee = memberService.findMember(request.getAssigneeId(), project.getId());
 
         Epic epic = getEpic(issue);

--- a/src/main/java/dynamicquad/agilehub/issue/service/factory/EpicFactory.java
+++ b/src/main/java/dynamicquad/agilehub/issue/service/factory/EpicFactory.java
@@ -16,8 +16,7 @@ import dynamicquad.agilehub.issue.domain.story.Story;
 import dynamicquad.agilehub.issue.domain.story.StoryRepository;
 import dynamicquad.agilehub.issue.service.ImageService;
 import dynamicquad.agilehub.member.domain.Member;
-import dynamicquad.agilehub.member.repository.MemberRepository;
-import dynamicquad.agilehub.project.domain.MemberProjectRepository;
+import dynamicquad.agilehub.member.service.MemberService;
 import dynamicquad.agilehub.project.domain.Project;
 import java.util.List;
 import java.util.Optional;
@@ -37,8 +36,7 @@ public class EpicFactory implements IssueFactory {
     private final StoryRepository storyRepository;
     private final ImageService imageService;
 
-    private final MemberRepository memberRepository;
-    private final MemberProjectRepository memberProjectRepository;
+    private final MemberService memberService;
 
     @Value("${aws.s3.workingDirectory.issue}")
     private String WORKING_DIRECTORY;
@@ -51,8 +49,8 @@ public class EpicFactory implements IssueFactory {
         // TODO: 이슈가 삭제되면 이슈 번호가 중복될 수 있음 1번,2번,3번 이슈 생성뒤 2번 삭제하면 4번 이슈 생성시 3번이 되어 중복 [ ]
         // TODO: 이슈 번호 생성 로직을 따로 만들기 - number 최대로 큰 숫자 + 1로 로직 변경 [ ]
         int issueNumber = (int) (issueRepository.countByProjectKey(project.getKey()) + 1);
-        // TODO: 멤버 클래스에 이 로직을 따로 만들기 [ ]
-        Member assignee = findMember(request.getAssigneeId(), project.getId());
+
+        Member assignee = memberService.findMember(request.getAssigneeId(), project.getId());
 
         // TODO: EPIC toEntity 메서드에 이 로직 넣기 [ ]
         Epic epic = Epic.builder()
@@ -77,8 +75,8 @@ public class EpicFactory implements IssueFactory {
     @Transactional
     @Override
     public Long updateIssue(Issue issue, Project project, IssueEditRequest request) {
-        // TODO: 멤버 클래스에 이 로직을 따로 만들기 [ ]
-        Member assignee = findMember(request.getAssigneeId(), project.getId());
+        // TODO: 멤버 클래스에 이 로직을 따로 만들기 [x]
+        Member assignee = memberService.findMember(request.getAssigneeId(), project.getId());
 
         Epic epic = getEpic(issue);
         epic.updateEpic(request, assignee);
@@ -160,18 +158,6 @@ public class EpicFactory implements IssueFactory {
             throw new GeneralException(ErrorStatus.ISSUE_TYPE_NOT_FOUND);
         }
         return epic;
-    }
-
-    //TODO: 멤버 클래스에 이 로직을 따로 만들기 [ ]
-    public Member findMember(Long assigneeId, Long projectId) {
-        if (assigneeId == null) {
-            return null;
-        }
-        Member member = memberRepository.findById(assigneeId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        memberProjectRepository.findByMemberIdAndProjectId(member.getId(), projectId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
-        return member;
     }
 
 

--- a/src/main/java/dynamicquad/agilehub/issue/service/factory/TaskFactory.java
+++ b/src/main/java/dynamicquad/agilehub/issue/service/factory/TaskFactory.java
@@ -14,8 +14,7 @@ import dynamicquad.agilehub.issue.domain.IssueRepository;
 import dynamicquad.agilehub.issue.domain.story.Story;
 import dynamicquad.agilehub.issue.domain.task.Task;
 import dynamicquad.agilehub.member.domain.Member;
-import dynamicquad.agilehub.member.repository.MemberRepository;
-import dynamicquad.agilehub.project.domain.MemberProjectRepository;
+import dynamicquad.agilehub.member.service.MemberService;
 import dynamicquad.agilehub.project.domain.Project;
 import java.util.List;
 import java.util.Optional;
@@ -31,8 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TaskFactory implements IssueFactory {
 
     private final IssueRepository issueRepository;
-    private final MemberProjectRepository memberProjectRepository;
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
     private final String TASK = "TASK";
     private final String STORY = "STORY";
@@ -43,8 +41,9 @@ public class TaskFactory implements IssueFactory {
         // TODO: 이슈가 삭제되면 이슈 번호가 중복될 수 있음 1번,2번,3번 이슈 생성뒤 2번 삭제하면 4번 이슈 생성시 3번이 되어 중복 [ ]
         // TODO: 이슈 번호 생성 로직을 따로 만들기 - number 최대로 큰 숫자 + 1로 로직 변경 [ ]
         int issueNumber = (int) (issueRepository.countByProjectKey(project.getKey()) + 1);
-        // TODO: 멤버 클래스에 이 로직을 따로 만들기 [ ]
-        Member assignee = findMember(request.getAssigneeId(), project.getId());
+
+        Member assignee = memberService.findMember(request.getAssigneeId(), project.getId());
+
         Story upStory = retrieveStoryFromParentIssue(request.getParentId());
 
         // TODO: TASK toEntity 메서드에 이 로직 넣기 [ ]
@@ -64,8 +63,8 @@ public class TaskFactory implements IssueFactory {
 
     @Override
     public Long updateIssue(Issue issue, Project project, IssueEditRequest request) {
-        // TODO: 멤버 클래스에 이 로직을 따로 만들기 [ ]
-        Member assignee = findMember(request.getAssigneeId(), project.getId());
+
+        Member assignee = memberService.findMember(request.getAssigneeId(), project.getId());
 
         Task task = getTask(issue);
         Story upStory = retrieveStoryFromParentIssue(request.getParentId());
@@ -158,18 +157,4 @@ public class TaskFactory implements IssueFactory {
 
     }
 
-    //TODO: 멤버 클래스에 이 로직을 따로 만들기 [ ]
-    private Member findMember(Long assigneeId, Long projectId) {
-
-        if (assigneeId == null) {
-            return null;
-        }
-
-        Member member = memberRepository.findById(assigneeId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        memberProjectRepository.findByMemberIdAndProjectId(member.getId(), projectId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
-
-        return member;
-    }
 }

--- a/src/main/java/dynamicquad/agilehub/member/domain/Member.java
+++ b/src/main/java/dynamicquad/agilehub/member/domain/Member.java
@@ -43,9 +43,18 @@ public class Member extends BaseEntity {
         this.status = status;
     }
 
+    private Member(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public void update(String name, String profileImageUrl) {
         this.name = name;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    public static Member createPojoByAuthMember(Long id, String name) {
+        return new Member(id, name);
     }
 
 }

--- a/src/main/java/dynamicquad/agilehub/member/dto/MemberRequestDto.java
+++ b/src/main/java/dynamicquad/agilehub/member/dto/MemberRequestDto.java
@@ -31,4 +31,14 @@ public class MemberRequestDto {
         private String distinctId;
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AuthMember {
+        private Long id;
+        private String name;
+        private String profileImageUrl;
+    }
+
 }

--- a/src/main/java/dynamicquad/agilehub/member/service/MemberService.java
+++ b/src/main/java/dynamicquad/agilehub/member/service/MemberService.java
@@ -1,10 +1,6 @@
 package dynamicquad.agilehub.member.service;
 
-import dynamicquad.agilehub.global.exception.GeneralException;
-import dynamicquad.agilehub.global.header.status.ErrorStatus;
-import dynamicquad.agilehub.member.converter.MemberConverter;
 import dynamicquad.agilehub.member.domain.Member;
-import dynamicquad.agilehub.member.dto.MemberRequestDto;
 import dynamicquad.agilehub.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/dynamicquad/agilehub/member/service/MemberService.java
+++ b/src/main/java/dynamicquad/agilehub/member/service/MemberService.java
@@ -33,4 +33,10 @@ public class MemberService {
         return member;
     }
 
+    public void validateMemberExist(Long memberId) {
+        if (!memberRepository.existsById(memberId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+        }
+    }
+
 }

--- a/src/main/java/dynamicquad/agilehub/member/service/MemberService.java
+++ b/src/main/java/dynamicquad/agilehub/member/service/MemberService.java
@@ -1,7 +1,10 @@
 package dynamicquad.agilehub.member.service;
 
+import dynamicquad.agilehub.global.exception.GeneralException;
+import dynamicquad.agilehub.global.header.status.ErrorStatus;
 import dynamicquad.agilehub.member.domain.Member;
 import dynamicquad.agilehub.member.repository.MemberRepository;
+import dynamicquad.agilehub.project.service.MemberProjectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +15,22 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final MemberProjectService memberProjectService;
 
     public Member save(Member member) {
         return memberRepository.save(member);
+    }
+
+    public Member findMember(Long assigneeId, Long projectId) {
+        if (assigneeId == null) {
+            return null;
+        }
+        Member member = memberRepository.findById(assigneeId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        memberProjectService.validateMemberInProject(member.getId(), projectId);
+
+        return member;
     }
 
 }

--- a/src/main/java/dynamicquad/agilehub/project/controller/ProjectController.java
+++ b/src/main/java/dynamicquad/agilehub/project/controller/ProjectController.java
@@ -74,9 +74,10 @@ public class ProjectController {
         @ApiResponse(responseCode = "404", description = "프로젝트가 존재하지 않습니다.")
     })
     @PutMapping("/projects/{key}")
-    public ResponseEntity<?> updateProject(@RequestBody @Valid ProjectUpdateRequest request, @PathVariable String key) {
+    public ResponseEntity<?> updateProject(@RequestBody @Valid ProjectUpdateRequest request, @PathVariable String key,
+                                           @Auth AuthMember authMember) {
 
-        String updateKey = projectService.updateProject(key, request);
+        String updateKey = projectService.updateProject(key, request, authMember);
         return ResponseEntity.created(URI.create("/projects/" + updateKey + "/issues"))
             .body(CommonResponse.of(SuccessStatus.CREATED, updateKey));
     }

--- a/src/main/java/dynamicquad/agilehub/project/controller/ProjectController.java
+++ b/src/main/java/dynamicquad/agilehub/project/controller/ProjectController.java
@@ -6,7 +6,7 @@ import static dynamicquad.agilehub.project.controller.request.ProjectRequest.Pro
 import dynamicquad.agilehub.global.auth.model.Auth;
 import dynamicquad.agilehub.global.header.CommonResponse;
 import dynamicquad.agilehub.global.header.status.SuccessStatus;
-import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.controller.response.ProjectResponse;
 import dynamicquad.agilehub.project.service.ProjectQueryService;
 import dynamicquad.agilehub.project.service.ProjectService;
@@ -60,11 +60,9 @@ public class ProjectController {
         @ApiResponse(responseCode = "404", description = "프로젝트가 존재하지 않습니다.")
     })
     @GetMapping("/projects")
-    public CommonResponse<?> getProjects(@Auth Member member) {
+    public CommonResponse<?> getProjects(@Auth AuthMember authMember) {
 
-        final Long memberId = member.getId();
-
-        List<ProjectResponse> projects = projectQueryService.getProjects(memberId);
+        List<ProjectResponse> projects = projectQueryService.getProjects(authMember.getId());
         return CommonResponse.onSuccess(projects);
     }
 

--- a/src/main/java/dynamicquad/agilehub/project/controller/ProjectController.java
+++ b/src/main/java/dynamicquad/agilehub/project/controller/ProjectController.java
@@ -45,9 +45,10 @@ public class ProjectController {
         @ApiResponse(responseCode = "400", description = "프로젝트 키가 중복됩니다."),
     })
     @PostMapping("/projects")
-    public ResponseEntity<?> createProject(@RequestBody @Valid ProjectCreateRequest request) {
+    public ResponseEntity<?> createProject(@RequestBody @Valid ProjectCreateRequest request,
+                                           @Auth AuthMember authMember) {
 
-        String key = projectService.createProject(request);
+        String key = projectService.createProject(request, authMember);
         return ResponseEntity.created(URI.create("/projects/" + key + "/issues"))
             .body(CommonResponse.of(SuccessStatus.CREATED, key));
     }

--- a/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
@@ -2,8 +2,12 @@ package dynamicquad.agilehub.project.service;
 
 import dynamicquad.agilehub.global.exception.GeneralException;
 import dynamicquad.agilehub.global.header.status.ErrorStatus;
+import dynamicquad.agilehub.member.domain.Member;
 import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.domain.MemberProject;
 import dynamicquad.agilehub.project.domain.MemberProjectRepository;
+import dynamicquad.agilehub.project.domain.MemberProjectRole;
+import dynamicquad.agilehub.project.domain.Project;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,20 @@ public class MemberProjectService {
         Long memberId = authMember.getId();
         memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
+    }
+
+
+    @Transactional
+    public void createMemberProject(AuthMember authMember, Project project, MemberProjectRole role) {
+        Member member = Member.createPojoByAuthMember(authMember.getId(), authMember.getName());
+
+        MemberProject memberProject = MemberProject.builder()
+            .member(member)
+            .project(project)
+            .role(role)
+            .build();
+
+        memberProjectRepository.save(memberProject);
     }
 
 }

--- a/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
@@ -8,6 +8,7 @@ import dynamicquad.agilehub.project.domain.MemberProject;
 import dynamicquad.agilehub.project.domain.MemberProjectRepository;
 import dynamicquad.agilehub.project.domain.MemberProjectRole;
 import dynamicquad.agilehub.project.domain.Project;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,12 +19,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberProjectService {
 
     private final MemberProjectRepository memberProjectRepository;
-
-    public void validateMemberInProject(Long memberId, Long projectId) {
-        memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
-            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
-    }
-
 
     @Transactional
     public void createMemberProject(AuthMember authMember, Project project, MemberProjectRole role) {
@@ -38,6 +33,14 @@ public class MemberProjectService {
         memberProjectRepository.save(memberProject);
     }
 
+    public List<Project> findProjects(Long memberId) {
+        return memberProjectRepository.findProjectsByMemberId(memberId);
+    }
+
+    public void validateMemberInProject(Long memberId, Long projectId) {
+        memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
+    }
 
     public void validateUpdateProjectAuth(AuthMember authMember, Long projectId) {
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(authMember.getId(), projectId)

--- a/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
@@ -42,7 +42,7 @@ public class MemberProjectService {
             .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
     }
 
-    public void validateUpdateProjectAuth(AuthMember authMember, Long projectId) {
+    public void validateMemberRole(AuthMember authMember, Long projectId) {
         MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(authMember.getId(), projectId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
 

--- a/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
@@ -1,0 +1,24 @@
+package dynamicquad.agilehub.project.service;
+
+import dynamicquad.agilehub.global.exception.GeneralException;
+import dynamicquad.agilehub.global.header.status.ErrorStatus;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.domain.MemberProjectRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberProjectService {
+
+    private final MemberProjectRepository memberProjectRepository;
+
+    public void validateMemberInProject(AuthMember authMember, Long projectId) {
+        Long memberId = authMember.getId();
+        memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
+    }
+
+}

--- a/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
@@ -20,8 +20,7 @@ public class MemberProjectService {
     private final MemberProjectRepository memberProjectRepository;
 
     public void validateMemberInProject(AuthMember authMember, Long projectId) {
-        Long memberId = authMember.getId();
-        memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
+        memberProjectRepository.findByMemberIdAndProjectId(authMember.getId(), projectId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
     }
 
@@ -39,4 +38,13 @@ public class MemberProjectService {
         memberProjectRepository.save(memberProject);
     }
 
+
+    public void validateUpdateProjectAuth(AuthMember authMember, Long projectId) {
+        MemberProject memberProject = memberProjectRepository.findByMemberIdAndProjectId(authMember.getId(), projectId)
+            .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
+
+        if (memberProject.getRole() != MemberProjectRole.ADMIN) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_ADMIN);
+        }
+    }
 }

--- a/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/MemberProjectService.java
@@ -19,8 +19,8 @@ public class MemberProjectService {
 
     private final MemberProjectRepository memberProjectRepository;
 
-    public void validateMemberInProject(AuthMember authMember, Long projectId) {
-        memberProjectRepository.findByMemberIdAndProjectId(authMember.getId(), projectId)
+    public void validateMemberInProject(Long memberId, Long projectId) {
+        memberProjectRepository.findByMemberIdAndProjectId(memberId, projectId)
             .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_IN_PROJECT));
     }
 

--- a/src/main/java/dynamicquad/agilehub/project/service/ProjectQueryService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/ProjectQueryService.java
@@ -1,10 +1,7 @@
 package dynamicquad.agilehub.project.service;
 
-import dynamicquad.agilehub.global.exception.GeneralException;
-import dynamicquad.agilehub.global.header.status.ErrorStatus;
-import dynamicquad.agilehub.member.repository.MemberRepository;
+import dynamicquad.agilehub.member.service.MemberService;
 import dynamicquad.agilehub.project.controller.response.ProjectResponse;
-import dynamicquad.agilehub.project.domain.MemberProjectRepository;
 import dynamicquad.agilehub.project.domain.Project;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,21 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Transactional(readOnly = true)
 public class ProjectQueryService {
-    private final MemberProjectRepository memberProjectRepository;
-    private final MemberRepository memberRepository;
+
+    private final MemberService memberService;
+    private final MemberProjectService memberProjectService;
 
     public List<ProjectResponse> getProjects(Long memberId) {
-        // TODO: 멤버 존재 여부 확인 로직 따로 멤버 클래스로 분리하기 - [ ]
-        validateMemberExist(memberId);
-        List<Project> projects = memberProjectRepository.findProjectsByMemberId(memberId);
+
+        memberService.validateMemberExist(memberId);
+        List<Project> projects = memberProjectService.findProjects(memberId);
 
         return projects.stream().map(ProjectResponse::fromEntity).toList();
     }
 
-    private void validateMemberExist(Long memberId) {
-        if (!memberRepository.existsById(memberId)) {
-            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
-        }
-    }
 
 }

--- a/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
@@ -2,8 +2,10 @@ package dynamicquad.agilehub.project.service;
 
 import dynamicquad.agilehub.global.exception.GeneralException;
 import dynamicquad.agilehub.global.header.status.ErrorStatus;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.controller.request.ProjectRequest.ProjectCreateRequest;
 import dynamicquad.agilehub.project.controller.request.ProjectRequest.ProjectUpdateRequest;
+import dynamicquad.agilehub.project.domain.MemberProjectRole;
 import dynamicquad.agilehub.project.domain.Project;
 import dynamicquad.agilehub.project.domain.ProjectRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +21,15 @@ public class ProjectService {
 
     private final ProjectValidator projectValidator;
     private final ProjectRepository projectRepository;
+    private final MemberProjectService memberProjectService;
 
     @Transactional
-    public String createProject(ProjectCreateRequest request) {
+    public String createProject(ProjectCreateRequest request, AuthMember authMember) {
         validateKeyUniqueness(request.getKey());
-        //TODO: 프로젝트 생성 후 유저 - 멤버_프로젝트 - 프로젝트 매핑하는 로직 필요. role은 Admin으로 [ ]
-        return projectRepository.save(request.toEntity()).getKey();
+        Project project = projectRepository.save(request.toEntity());
+        memberProjectService.createMemberProject(authMember, project, MemberProjectRole.ADMIN);
+
+        return project.getKey();
     }
 
     @Transactional

--- a/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
@@ -36,10 +36,10 @@ public class ProjectService {
     @Transactional
     public String updateProject(String originKey, ProjectUpdateRequest request, AuthMember authMember) {
         Project project = projectValidator.findProject(originKey);
-        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
         memberProjectService.validateUpdateProjectAuth(authMember, project.getId());
         validateKeyUniqueness(request.getKey());
-        
+
         return project.updateProject(request).getKey();
     }
 

--- a/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
@@ -27,17 +27,19 @@ public class ProjectService {
     public String createProject(ProjectCreateRequest request, AuthMember authMember) {
         validateKeyUniqueness(request.getKey());
         Project project = projectRepository.save(request.toEntity());
+        // 프로젝트 생성자는 프로젝트에 대한 모든 권한을 가짐(ADMIN)
         memberProjectService.createMemberProject(authMember, project, MemberProjectRole.ADMIN);
 
         return project.getKey();
     }
 
     @Transactional
-    public String updateProject(String originKey, ProjectUpdateRequest request) {
+    public String updateProject(String originKey, ProjectUpdateRequest request, AuthMember authMember) {
         Project project = projectValidator.findProject(originKey);
-        //TODO: 해당 멤버가 프로젝트에 속해있는지 확인하는 로직 필요. [ ]
-        //TODO: 프로젝트 수정 권한이 있는지 확인하는 로직 필요. [ ] -> 프로젝트 생성자(ADMIN)만 수정 가능
+        memberProjectService.validateMemberInProject(authMember, project.getId());
+        memberProjectService.validateUpdateProjectAuth(authMember, project.getId());
         validateKeyUniqueness(request.getKey());
+        
         return project.updateProject(request).getKey();
     }
 

--- a/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
+++ b/src/main/java/dynamicquad/agilehub/project/service/ProjectService.java
@@ -37,7 +37,7 @@ public class ProjectService {
     public String updateProject(String originKey, ProjectUpdateRequest request, AuthMember authMember) {
         Project project = projectValidator.findProject(originKey);
         memberProjectService.validateMemberInProject(authMember.getId(), project.getId());
-        memberProjectService.validateUpdateProjectAuth(authMember, project.getId());
+        memberProjectService.validateMemberRole(authMember, project.getId());
         validateKeyUniqueness(request.getKey());
 
         return project.updateProject(request).getKey();

--- a/src/main/java/dynamicquad/agilehub/sprint/controller/SprintController.java
+++ b/src/main/java/dynamicquad/agilehub/sprint/controller/SprintController.java
@@ -4,8 +4,10 @@ import static dynamicquad.agilehub.sprint.controller.request.SprintRequest.Sprin
 import static dynamicquad.agilehub.sprint.controller.request.SprintRequest.SprintChangeStatusRequest;
 import static dynamicquad.agilehub.sprint.controller.request.SprintRequest.SprintCreateRequest;
 
+import dynamicquad.agilehub.global.auth.model.Auth;
 import dynamicquad.agilehub.global.header.CommonResponse;
 import dynamicquad.agilehub.global.header.status.SuccessStatus;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.sprint.controller.response.SprintResponse.SprintCreateResponse;
 import dynamicquad.agilehub.sprint.service.SprintQueryService;
 import dynamicquad.agilehub.sprint.service.SprintService;
@@ -36,9 +38,10 @@ public class SprintController {
     @Operation(summary = "스프린트 생성", description = "프로젝트에 스프린트를 생성합니다.")
     @PostMapping(value = "/projects/{key}/sprints")
     public ResponseEntity<?> createProjectSprint(@Valid @RequestBody SprintCreateRequest request,
-                                                 @PathVariable("key") String key) {
+                                                 @PathVariable("key") String key,
+                                                 @Auth AuthMember authMember) {
 
-        SprintCreateResponse resp = sprintService.createSprint(key, request);
+        SprintCreateResponse resp = sprintService.createSprint(key, request, authMember);
 
         return ResponseEntity.created(URI.create("/projects/" + key + "/sprints/" + resp.getSprintId()))
             .body(CommonResponse.of(SuccessStatus.CREATED, resp));
@@ -48,9 +51,10 @@ public class SprintController {
     @PostMapping(value = "/projects/{key}/sprints/{sprintId}/issue")
     public ResponseEntity<?> assignIssueToSprint(@Valid @RequestBody SprintAssignIssueRequest request,
                                                  @PathVariable("key") String key,
-                                                 @PathVariable("sprintId") Long sprintId) {
+                                                 @PathVariable("sprintId") Long sprintId,
+                                                 @Auth AuthMember authMember) {
 
-        sprintService.assignIssueToSprint(key, sprintId, request.getIssueId());
+        sprintService.assignIssueToSprint(key, sprintId, request.getIssueId(), authMember);
 
         return ResponseEntity.noContent().build();
     }
@@ -59,9 +63,10 @@ public class SprintController {
     @DeleteMapping(value = "/projects/{key}/sprints/{sprintId}/issue")
     public ResponseEntity<?> removeIssueFromSprint(@Valid @RequestBody SprintAssignIssueRequest request,
                                                    @PathVariable("key") String key,
-                                                   @PathVariable("sprintId") Long sprintId) {
+                                                   @PathVariable("sprintId") Long sprintId,
+                                                   @Auth AuthMember authMember) {
 
-        sprintService.removeIssueFromSprint(key, sprintId, request.getIssueId());
+        sprintService.removeIssueFromSprint(key, sprintId, request.getIssueId(), authMember);
 
         return ResponseEntity.noContent().build();
     }
@@ -70,9 +75,10 @@ public class SprintController {
     @PatchMapping(value = "/projects/{key}/sprints/{sprintId}/status")
     public ResponseEntity<?> changeSprintStatus(@Valid @RequestBody SprintChangeStatusRequest request,
                                                 @PathVariable("key") String key,
-                                                @PathVariable("sprintId") Long sprintId) {
+                                                @PathVariable("sprintId") Long sprintId,
+                                                @Auth AuthMember authMember) {
 
-        sprintService.changeSprintStatus(key, sprintId, request.getStatus());
+        sprintService.changeSprintStatus(key, sprintId, request.getStatus(), authMember);
 
         return ResponseEntity.noContent().build();
     }
@@ -87,9 +93,10 @@ public class SprintController {
     @Operation(summary = "스프린트 삭제", description = "스프린트를 삭제합니다")
     @DeleteMapping(value = "/projects/{key}/sprints/{sprintId}")
     public ResponseEntity<?> deleteSprint(@PathVariable("key") String key,
-                                          @PathVariable("sprintId") Long sprintId) {
+                                          @PathVariable("sprintId") Long sprintId,
+                                          @Auth AuthMember authMember) {
 
-        sprintService.deleteSprint(key, sprintId);
+        sprintService.deleteSprint(key, sprintId, authMember);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/dynamicquad/agilehub/issue/comment/CommentServiceTest.java
+++ b/src/test/java/dynamicquad/agilehub/issue/comment/CommentServiceTest.java
@@ -8,6 +8,9 @@ import dynamicquad.agilehub.issue.comment.service.CommentService;
 import dynamicquad.agilehub.issue.domain.IssueStatus;
 import dynamicquad.agilehub.issue.domain.epic.Epic;
 import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.domain.MemberProject;
+import dynamicquad.agilehub.project.domain.MemberProjectRole;
 import dynamicquad.agilehub.project.domain.Project;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -41,9 +44,20 @@ class CommentServiceTest {
             .build();
         em.persist(member);
 
+        MemberProject memberProject = MemberProject.builder()
+            .member(member)
+            .project(project1)
+            .role(MemberProjectRole.ADMIN)
+            .build();
+        em.persist(memberProject);
+
+        AuthMember authMember = AuthMember.builder()
+            .id(member.getId())
+            .build();
+
         // when
         CommentCreateResponse commentCreateResponse = commentService.createComment(project1.getKey(), epic1P1.getId(),
-            member.getId(), "코멘트 내용");
+            "코멘트 내용", authMember);
 
         // then
         assertThat(commentCreateResponse).isNotNull();
@@ -68,6 +82,13 @@ class CommentServiceTest {
             .build();
         em.persist(member);
 
+        MemberProject memberProject = MemberProject.builder()
+            .member(member)
+            .project(project1)
+            .role(MemberProjectRole.ADMIN)
+            .build();
+        em.persist(memberProject);
+
         Comment comment = Comment.builder()
             .content("코멘트 내용")
             .writer(member)
@@ -76,8 +97,12 @@ class CommentServiceTest {
 
         em.persist(comment);
 
+        AuthMember authMember = AuthMember.builder()
+            .id(member.getId())
+            .build();
+
         //when
-        commentService.updateComment(project1.getKey(), epic1P1.getId(), comment.getId(), "수정된 코멘트 내용", member.getId());
+        commentService.updateComment(project1.getKey(), epic1P1.getId(), comment.getId(), "수정된 코멘트 내용", authMember);
 
         //then
         Comment findComment = em.find(Comment.class, comment.getId());

--- a/src/test/java/dynamicquad/agilehub/issue/service/IssueServiceTest.java
+++ b/src/test/java/dynamicquad/agilehub/issue/service/IssueServiceTest.java
@@ -6,6 +6,10 @@ import dynamicquad.agilehub.issue.domain.IssueStatus;
 import dynamicquad.agilehub.issue.domain.epic.Epic;
 import dynamicquad.agilehub.issue.domain.story.Story;
 import dynamicquad.agilehub.issue.domain.task.Task;
+import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.domain.MemberProject;
+import dynamicquad.agilehub.project.domain.MemberProjectRole;
 import dynamicquad.agilehub.project.domain.Project;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -41,8 +45,23 @@ class IssueServiceTest {
         Story story2P1 = createStory("스토리2", "스토리2 내용", project1, epic2P1);
         em.persist(story2P1);
 
+        Member member = Member.builder().name("member").build();
+        em.persist(member);
+
+        MemberProject memberProject = MemberProject.builder()
+            .member(member)
+            .project(project1)
+            .role(MemberProjectRole.ADMIN)
+            .build();
+        em.persist(memberProject);
+
+        AuthMember authMember = AuthMember.builder()
+            .id(member.getId())
+            .name("member")
+            .build();
+
         // when
-        issueService.deleteIssue(project1.getKey(), epic2P1.getId());
+        issueService.deleteIssue(project1.getKey(), epic2P1.getId(), authMember);
         em.flush();
         em.clear();
         // then

--- a/src/test/java/dynamicquad/agilehub/project/service/ProjectServiceTest.java
+++ b/src/test/java/dynamicquad/agilehub/project/service/ProjectServiceTest.java
@@ -5,10 +5,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import dynamicquad.agilehub.global.exception.GeneralException;
 import dynamicquad.agilehub.global.header.status.ErrorStatus;
+import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.controller.request.ProjectRequest.ProjectCreateRequest;
 import dynamicquad.agilehub.project.controller.request.ProjectRequest.ProjectUpdateRequest;
 import dynamicquad.agilehub.project.domain.Project;
 import dynamicquad.agilehub.project.domain.ProjectRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,17 +30,29 @@ class ProjectServiceTest {
     @Autowired
     private ProjectRepository projectRepository;
 
+    @PersistenceContext
+    EntityManager em;
 
     @Test
     @Transactional
     void 신규프로젝트를_등록한다_성공시_key_반환() {
         // given
+        Member member = Member.builder()
+            .name("test")
+            .build();
+        em.persist(member);
+
         ProjectCreateRequest request = ProjectCreateRequest.builder()
             .name("프로젝트1")
             .key("PK1")
             .build();
+
+        AuthMember authMember = AuthMember.builder()
+            .id(member.getId())
+            .name("test")
+            .build();
         // then
-        assertThat(projectService.createProject(request))
+        assertThat(projectService.createProject(request, authMember))
             .isEqualTo("PK1");
     }
 
@@ -48,10 +64,12 @@ class ProjectServiceTest {
             .name("프로젝트1")
             .key("PK1")
             .build();
-        // when
-        projectService.createProject(request);
+        AuthMember authMember = AuthMember.builder()
+            .id(1L)
+            .name("test")
+            .build();
         // then
-        assertThatThrownBy(() -> projectService.createProject(request))
+        assertThatThrownBy(() -> projectService.createProject(request, authMember))
             .isInstanceOf(RuntimeException.class);
     }
 

--- a/src/test/java/dynamicquad/agilehub/sprint/SprintServiceTest.java
+++ b/src/test/java/dynamicquad/agilehub/sprint/SprintServiceTest.java
@@ -2,6 +2,10 @@ package dynamicquad.agilehub.sprint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dynamicquad.agilehub.member.domain.Member;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.domain.MemberProject;
+import dynamicquad.agilehub.project.domain.MemberProjectRole;
 import dynamicquad.agilehub.project.domain.Project;
 import dynamicquad.agilehub.sprint.controller.request.SprintRequest.SprintCreateRequest;
 import dynamicquad.agilehub.sprint.controller.response.SprintResponse.SprintCreateResponse;
@@ -41,8 +45,24 @@ class SprintServiceTest {
             .endDate(LocalDate.of(2021, 1, 2))
             .build();
 
+        Member member = Member.builder()
+            .name("member1")
+            .build();
+        em.persist(member);
+
+        MemberProject memberProject = MemberProject.builder()
+            .member(member)
+            .project(project)
+            .role(MemberProjectRole.ADMIN)
+            .build();
+        em.persist(memberProject);
+
+        AuthMember authMember = AuthMember.builder()
+            .id(member.getId())
+            .build();
+
         // when
-        SprintCreateResponse resp = sprintService.createSprint(project.getKey(), request);
+        SprintCreateResponse resp = sprintService.createSprint(project.getKey(), request, authMember);
         em.flush();
 
         // then


### PR DESCRIPTION
## 📄 Summary

전에 달아놓은 TODO에 맞게 인증 로직을 API들에 추가 했습니다.

## 🕰️ Actual Time of Completion

4시간

## 🙋🏻 More

MemberArgumentResolver에서 Member 엔티티를 반환하는 대신 Dto로 반환하도록 했습니다