### PR TITLE
refactor: cors 에러 메서드 수정

### DIFF
--- a/src/main/java/dynamicquad/agilehub/global/config/SpringSecurityConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/SpringSecurityConfig.java
@@ -44,7 +44,7 @@ public class SpringSecurityConfig {
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .cors(cors -> cors.configurationSource(request -> {
                 CorsConfiguration config = new CorsConfiguration();
-                config.setAllowedOrigins(Collections.singletonList("*")); // 추후에 서버 도메인으로 변경 필요
+                config.setAllowedOriginPatterns(Collections.singletonList("*"));
                 config.setAllowedMethods(Collections.singletonList("*"));
                 config.setAllowedHeaders(Collections.singletonList("*"));
                 config.setAllowCredentials(true);


### PR DESCRIPTION
## 📄 Summary

Spring Framework에서 CORS(Cross-Origin Resource Sharing) 정책을 구성할 때 발생하는 문제를 설명하고 있습니다. allowCredentials 옵션이 true로 설정된 상황에서 allowedOrigins에 특별한 값인 "*"가 포함되어 있으면 안 된다는 내용입니다. 
이는 "*" 값을 "Access-Control-Allow-Origin" 응답 헤더에 설정할 수 없기 때문입니다. 
즉, 크레덴셜을 허용하려면 명시적으로 특정 도메인을 나열하거나 "allowedOriginPatterns"를 사용해야 합니다.

https://kim6394.tistory.com/273

## 🕰️ Actual Time of Completion

> 10분

## 🙋🏻 More

>