### PR TITLE
feat: 멤버 조회 API 구현

### DIFF
--- a/src/main/java/dynamicquad/agilehub/member/controller/MemberController.java
+++ b/src/main/java/dynamicquad/agilehub/member/controller/MemberController.java
@@ -1,0 +1,21 @@
+package dynamicquad.agilehub.member.controller;
+
+import dynamicquad.agilehub.global.auth.model.Auth;
+import dynamicquad.agilehub.global.header.CommonResponse;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "멤버", description = "멤버를 조회합니다")
+@RestController
+public class MemberController {
+
+    @Operation(summary = "멤버 조회", description = "멤버를 조회합니다")
+    @GetMapping("/member/profile")
+    public CommonResponse<?> getMember(@Auth AuthMember authMember) {
+
+        return CommonResponse.onSuccess(authMember);
+    }
+}


### PR DESCRIPTION
## 📄 Summary

> 로그인한 사용자의 프로필 사진, id, 이름을 조회합니다

## 🕰️ Actual Time of Completion

> 10분

## 🙋🏻 More

>