### PR TITLE
멤버 초대 이메일 서비스 비동기방식으로 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-# 로컬 DB 구성
 version: '3'
 
 services:
@@ -21,17 +20,41 @@ services:
       - app-network
     restart: always
 
-  redis:
+  redis-master:
     image: redis:7.0
-    container_name: redis
+    container_name: redis-master
     ports:
       - "0.0.0.0:6379:6379"
     volumes:
       - ./redis/data:/data
-    command: redis-server --appendonly yes
+    command: redis-server --requirepass ready!action --appendonly yes
     networks:
       - app-network
     restart: always
+
+  redis-slave1:
+    image: redis:7.0
+    container_name: redis-slave1
+    ports:
+      - "0.0.0.0:6380:6379"
+    command: redis-server --requirepass yourstrong!password --masterauth ready!action --replicaof redis-master 6379 --appendonly yes
+    networks:
+      - app-network
+    restart: always
+    depends_on:
+      - redis-master
+
+  redis-slave2:
+    image: redis:7.0
+    container_name: redis-slave2
+    ports:
+      - "0.0.0.0:6381:6379"
+    command: redis-server --requirepass yourstrong!password --masterauth ready!action --replicaof redis-master 6379 --appendonly yes
+    networks:
+      - app-network
+    restart: always
+    depends_on:
+      - redis-master
 
 networks:
   app-network:

--- a/src/main/java/dynamicquad/agilehub/global/config/AsyncConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/AsyncConfig.java
@@ -1,0 +1,29 @@
+package dynamicquad.agilehub.global.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    private static final boolean WAIT_TASK_COMPLETE = true;
+    private static final int AWAIT_TERMINATION_SECONDS = 30;
+
+    @Bean(name = "emailExecutor")
+    public Executor emailExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("email-");
+        executor.setWaitForTasksToCompleteOnShutdown(WAIT_TASK_COMPLETE);
+        executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+        executor.initialize();
+        
+        return executor;
+    }
+}

--- a/src/main/java/dynamicquad/agilehub/global/config/RedisConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/RedisConfig.java
@@ -19,6 +19,9 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.password}")
+    private String password;
+
     @Bean
     public RedisTemplate<String, String> redisTemplate() {
         RedisTemplate<String, String> template = new RedisTemplate<>();
@@ -31,6 +34,8 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(password);
+        
         return new LettuceConnectionFactory(config);
     }
 

--- a/src/main/java/dynamicquad/agilehub/global/mail/service/EmailService.java
+++ b/src/main/java/dynamicquad/agilehub/global/mail/service/EmailService.java
@@ -3,13 +3,19 @@ package dynamicquad.agilehub.global.mail.service;
 import dynamicquad.agilehub.global.exception.GeneralException;
 import dynamicquad.agilehub.global.header.status.ErrorStatus;
 import dynamicquad.agilehub.global.mail.model.EmailInfo;
+import dynamicquad.agilehub.issue.aspect.Retry;
 import dynamicquad.agilehub.project.model.InviteEmailInfo;
 import dynamicquad.agilehub.report.SummaryEmailInfo;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.thymeleaf.context.Context;
@@ -22,21 +28,37 @@ public class EmailService {
     private final JavaMailSender mailSender;
     private final SpringTemplateEngine templateEngine;
 
-    public void sendMail(EmailInfo emailInfo, String type) {
-        MimeMessage mimeMailMessage = mailSender.createMimeMessage();
-        try {
-            MimeMessageHelper helper = new MimeMessageHelper(mimeMailMessage, false, "UTF-8");
-            helper.setTo(emailInfo.getTo());
-            helper.setSubject(emailInfo.getSubject());
-            if (StringUtils.hasText(type)) {
-                helper.setText(setContext(emailInfo, type), true);
-            } else {
-                helper.setText(emailInfo.getMessage());
+    @Async("emailExecutor")
+    @Retry(maxRetries = 3, // 최대 3번 시도
+            retryFor = { MessagingException.class, MailSendException.class }, // 이메일 관련 예외만 재시도
+            delay = 1000 // 1초 대기 후 재시도
+    )
+    public CompletableFuture<Void> sendMail(EmailInfo emailInfo, String type) {
+        return CompletableFuture.runAsync(() -> {
+            try {
+                MimeMessage message = createMimeMessage(emailInfo, type);
+                mailSender.send(message);
+            } catch (MessagingException me) {
+                throw new GeneralException(ErrorStatus.EMAIL_NOT_SENT);
             }
-            mailSender.send(mimeMailMessage);
-        } catch (MessagingException me) {
-            throw new GeneralException(ErrorStatus.EMAIL_NOT_SENT);
-        }
+        });
+    }
+
+    private MimeMessage createMimeMessage(EmailInfo emailInfo, String type) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+
+        helper.setTo(emailInfo.getTo());
+        helper.setSubject(emailInfo.getSubject());
+        helper.setText(getEmailContent(emailInfo, type), true);
+
+        return mimeMessage;
+    }
+
+    private String getEmailContent(EmailInfo emailInfo, String type) {
+        return StringUtils.hasText(type)
+                ? setContext(emailInfo, type)
+                : emailInfo.getMessage();
     }
 
     private String setContext(EmailInfo emailInfo, String type) {

--- a/src/main/java/dynamicquad/agilehub/issue/aspect/Retry.java
+++ b/src/main/java/dynamicquad/agilehub/issue/aspect/Retry.java
@@ -8,4 +8,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Retry {
+    int maxRetries() default 5;
+
+    long delay() default 100;
+
+    Class<? extends Throwable>[] retryFor() default Exception.class;
 }

--- a/src/main/resources/application-redis.yml
+++ b/src/main/resources/application-redis.yml
@@ -3,6 +3,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: 6379
+      password: ready!action
 #      password:
 
 redis:


### PR DESCRIPTION
## 📄 Summary
 
> 이메일 전송시 ThreadPoolTaskExecutor를 구성하여 스레드 min = 5, max =30, 큐용량= 50으로 두고, CompletableFuture을 이용해 비동기처리 했습니다.
 
> 또한, 비동기처리 후, 이메일의 응답이 잘 처리되면 로그를 남겼으며 이메일 전송 실패시, Retry 어노테이션 구성으로 3번의 재시도 로직 후 예외 응답을 반환하도록 처리했습니다. 

> 한편, 저번 Redis 구성시 Replication으로 구성하게 되면서 Docker compose의 Replication 설정과 함께 Redis에 공격이 일어나는 로그가 잡혀 비밀번호도 추가적으로 구성했습니다. 하지만 깃허브상 노출이 되지만, 도메인이나 IP는 노출한적이 없어서 여기 코드에 공개합니다.