### PR TITLE
멤버 초대 이메일 발송 서비스 설계  및 고려 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
 
     // mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'com.amazonaws:aws-java-sdk-ses:1.12.408'
+
 
     // thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'

--- a/src/main/java/dynamicquad/agilehub/email/AmazonSESService.java
+++ b/src/main/java/dynamicquad/agilehub/email/AmazonSESService.java
@@ -31,7 +31,7 @@ public class AmazonSESService implements SMTPService {
 
     @Override
     @Async("emailExecutor")
-    @Retry(maxRetries = 3, retryFor = {GeneralException.class}, delay = 1000)
+    @Retry(maxRetries = 3, retryFor = {GeneralException.class}, delay = 500)
     public CompletableFuture<Void> sendEmail(String subject, Map<String, Object> variables, String... to) {
         // Amazon SES를 이용한 이메일 발송
         return CompletableFuture.runAsync(() -> {

--- a/src/main/java/dynamicquad/agilehub/email/AmazonSESService.java
+++ b/src/main/java/dynamicquad/agilehub/email/AmazonSESService.java
@@ -1,0 +1,53 @@
+package dynamicquad.agilehub.email;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.Body;
+import com.amazonaws.services.simpleemail.model.Content;
+import com.amazonaws.services.simpleemail.model.Destination;
+import com.amazonaws.services.simpleemail.model.Message;
+import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.context.IContext;
+
+@Service
+@RequiredArgsConstructor
+public class AmazonSESService implements SMTPService {
+
+    private final AmazonSimpleEmailService amazonSimpleEmailService;
+    private final TemplateEngine htmlTemplateEngine;
+
+    @Value("${aws.ses.from}")
+    private String from;
+
+    @Override
+    public void sendEmail(String subject, Map<String, Object> variables, String... to) {
+        // Amazon SES를 이용한 이메일 발송
+        String content = htmlTemplateEngine.process("invite", createContext(variables));
+        SendEmailRequest request = createSendEmailRequest(subject, content, to);
+
+        amazonSimpleEmailService.sendEmail(request);
+
+    }
+
+    private SendEmailRequest createSendEmailRequest(String subject, String content, String... to) {
+        return new SendEmailRequest()
+            .withDestination(new Destination().withToAddresses(to))
+            .withMessage(new Message()
+                .withBody(new Body()
+                    .withHtml(new Content().withCharset("UTF-8").withData(content)))
+                .withSubject(new Content().withCharset("UTF-8").withData(subject)))
+            .withSource(from);
+    }
+
+    private IContext createContext(Map<String, Object> variables) {
+        Context context = new Context();
+        context.setVariables(variables);
+
+        return context;
+    }
+}

--- a/src/main/java/dynamicquad/agilehub/email/InvitationController.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationController.java
@@ -1,10 +1,10 @@
 package dynamicquad.agilehub.email;
 
 import dynamicquad.agilehub.global.auth.model.Auth;
-import dynamicquad.agilehub.global.header.CommonResponse;
 import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.controller.request.ProjectInviteRequestDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,10 +18,10 @@ public class InvitationController {
     private final InvitationService invitationService;
 
     @PostMapping
-    public CommonResponse<String> inviteMember(@Auth AuthMember authMember,
-                                               @RequestBody ProjectInviteRequestDto.SendInviteMail sendInviteMail) {
+    public ResponseEntity<Void> inviteMember(@Auth AuthMember authMember,
+                                             @RequestBody ProjectInviteRequestDto.SendInviteMail sendInviteMail) {
         invitationService.sendInvitation(authMember, sendInviteMail);
-        return CommonResponse.onSuccess("초대 이메일이 발송되었습니다.");
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/dynamicquad/agilehub/email/InvitationController.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationController.java
@@ -1,0 +1,28 @@
+package dynamicquad.agilehub.email;
+
+import dynamicquad.agilehub.global.auth.model.Auth;
+import dynamicquad.agilehub.global.header.CommonResponse;
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.controller.request.ProjectInviteRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/invitations")
+public class InvitationController {
+
+    private final InvitationService invitationService;
+
+    @PostMapping
+    public CommonResponse<String> inviteMember(@Auth AuthMember authMember,
+                                               @RequestBody ProjectInviteRequestDto.SendInviteMail sendInviteMail) {
+        invitationService.sendInvitation(authMember, sendInviteMail);
+        return CommonResponse.onSuccess("초대 이메일이 발송되었습니다.");
+    }
+
+
+}

--- a/src/main/java/dynamicquad/agilehub/email/InvitationService.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationService.java
@@ -1,0 +1,12 @@
+package dynamicquad.agilehub.email;
+
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.controller.request.ProjectInviteRequestDto;
+
+public interface InvitationService {
+    void sendInvitation(AuthMember authMember, ProjectInviteRequestDto.SendInviteMail sendInviteMail);
+
+    //초대토큰 유효한지 확인
+    void validateInvitation(String inviteToken);
+}
+

--- a/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 public class InvitationServiceImpl implements InvitationService {
 
     private final MemberProjectService memberProjectService;
+    
 
     @Override
     public void sendInvitation(AuthMember authMember, SendInviteMail sendInviteMail) {
@@ -21,6 +22,10 @@ public class InvitationServiceImpl implements InvitationService {
 
         // 초대 토큰 생성
         String token = generateInviteToken();
+
+        // 초대 토큰 저장
+
+        // 이메일 전송
     }
 
     private String generateInviteToken() {

--- a/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
@@ -1,5 +1,6 @@
 package dynamicquad.agilehub.email;
 
+import dynamicquad.agilehub.global.util.RandomStringUtil;
 import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.controller.request.ProjectInviteRequestDto.SendInviteMail;
 import dynamicquad.agilehub.project.service.MemberProjectService;
@@ -23,7 +24,7 @@ public class InvitationServiceImpl implements InvitationService {
     }
 
     private String generateInviteToken() {
-        return null;
+        return RandomStringUtil.generateUUID();
     }
 
     @Override

--- a/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
@@ -1,0 +1,33 @@
+package dynamicquad.agilehub.email;
+
+import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
+import dynamicquad.agilehub.project.controller.request.ProjectInviteRequestDto.SendInviteMail;
+import dynamicquad.agilehub.project.service.MemberProjectService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InvitationServiceImpl implements InvitationService {
+
+    private final MemberProjectService memberProjectService;
+
+    @Override
+    public void sendInvitation(AuthMember authMember, SendInviteMail sendInviteMail) {
+        // 멤버 유효검사
+        memberProjectService.validateMemberInProject(authMember.getId(), sendInviteMail.getProjectId());
+        memberProjectService.validateMemberRole(authMember, sendInviteMail.getProjectId());
+
+        // 초대 토큰 생성
+        String token = generateInviteToken();
+    }
+
+    private String generateInviteToken() {
+        return null;
+    }
+
+    @Override
+    public void validateInvitation(String inviteToken) {
+
+    }
+}

--- a/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationServiceImpl.java
@@ -4,7 +4,12 @@ import dynamicquad.agilehub.global.util.RandomStringUtil;
 import dynamicquad.agilehub.member.dto.MemberRequestDto.AuthMember;
 import dynamicquad.agilehub.project.controller.request.ProjectInviteRequestDto.SendInviteMail;
 import dynamicquad.agilehub.project.service.MemberProjectService;
+import dynamicquad.agilehub.project.service.ProjectQueryService;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,20 +17,51 @@ import org.springframework.stereotype.Service;
 public class InvitationServiceImpl implements InvitationService {
 
     private final MemberProjectService memberProjectService;
-    
+    private final RedisTemplate redisTemplate;
+    private final SMTPService smtpService;
+    private final ProjectQueryService projectQueryService;
+
+    private static final String INVITATION_KEY_PREFIX = "invitation:";
+    private static final int EXPIRATION_MINUTES = 10;
 
     @Override
     public void sendInvitation(AuthMember authMember, SendInviteMail sendInviteMail) {
         // 멤버 유효검사
-        memberProjectService.validateMemberInProject(authMember.getId(), sendInviteMail.getProjectId());
-        memberProjectService.validateMemberRole(authMember, sendInviteMail.getProjectId());
+        validateMember(authMember, sendInviteMail.getProjectId());
 
         // 초대 토큰 생성
         String token = generateInviteToken();
-
-        // 초대 토큰 저장
+        storeInviteToken(token, sendInviteMail);
 
         // 이메일 전송
+        sendEmail(sendInviteMail, token);
+    }
+
+    private void sendEmail(SendInviteMail sendInviteMail, String token) {
+        final String projectName = projectQueryService.findProjectById(sendInviteMail.getProjectId()).getName();
+
+        Map<String, Object> variables = new HashMap<>();
+        variables.put("inviteCode", token);
+        variables.put("projectName", projectName);
+
+        smtpService.sendEmail("AgileHub 초대 메일", variables, sendInviteMail.getEmail());
+    }
+
+    private void storeInviteToken(String token, SendInviteMail sendInviteMail) {
+        String key = INVITATION_KEY_PREFIX + token;
+        Map<String, String> fields = new HashMap<>();
+        fields.put("projectId", Long.toString(sendInviteMail.getProjectId()));
+        fields.put("email", sendInviteMail.getEmail());
+        fields.put("used", "false");
+        fields.put("createdAt", String.valueOf(System.currentTimeMillis()));
+
+        redisTemplate.opsForHash().putAll(key, fields);
+        redisTemplate.expire(key, EXPIRATION_MINUTES, TimeUnit.MINUTES);
+    }
+
+    private void validateMember(AuthMember authMember, long projectId) {
+        memberProjectService.validateMemberInProject(authMember.getId(), projectId);
+        memberProjectService.validateMemberRole(authMember, projectId);
     }
 
     private String generateInviteToken() {

--- a/src/main/java/dynamicquad/agilehub/email/InvitationStatus.java
+++ b/src/main/java/dynamicquad/agilehub/email/InvitationStatus.java
@@ -1,0 +1,26 @@
+package dynamicquad.agilehub.email;
+
+public enum InvitationStatus {
+    PENDING,    // 초기 상태
+    SENDING,    // 발송 중
+    SENT,       // 발송 완료
+    RETRY,      // 재시도 대기
+    FAILED      // 최종 실패
+    ;
+
+
+    // string을 전달하면 enum으로 변환
+    public static InvitationStatus fromString(String status) {
+        return InvitationStatus.valueOf(status.toUpperCase());
+    }
+
+    public static boolean isPendingOrSending(String status) {
+        InvitationStatus invitationStatus = fromString(status);
+        return invitationStatus == PENDING || invitationStatus == SENDING;
+    }
+
+    public static boolean isFailed(String status) {
+        InvitationStatus invitationStatus = fromString(status);
+        return invitationStatus == FAILED;
+    }
+}

--- a/src/main/java/dynamicquad/agilehub/email/SMTPService.java
+++ b/src/main/java/dynamicquad/agilehub/email/SMTPService.java
@@ -1,7 +1,8 @@
 package dynamicquad.agilehub.email;
 
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 public interface SMTPService {
-    void sendEmail(String subject, Map<String, Object> variables, String... to);
+    CompletableFuture<Void> sendEmail(String subject, Map<String, Object> variables, String... to);
 }

--- a/src/main/java/dynamicquad/agilehub/email/SMTPService.java
+++ b/src/main/java/dynamicquad/agilehub/email/SMTPService.java
@@ -1,0 +1,7 @@
+package dynamicquad.agilehub.email;
+
+import java.util.Map;
+
+public interface SMTPService {
+    void sendEmail(String subject, Map<String, Object> variables, String... to);
+}

--- a/src/main/java/dynamicquad/agilehub/global/config/AsyncConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/AsyncConfig.java
@@ -17,9 +17,9 @@ public class AsyncConfig {
     @Bean(name = "emailExecutor")
     public Executor emailExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(5);
-        executor.setMaxPoolSize(30);
-        executor.setQueueCapacity(50);
+        executor.setCorePoolSize(4); // IO 바운드 작업: 코어수 * 2
+        executor.setMaxPoolSize(44); // CorePoolSize * (1 + 대기시간/서비스시간)
+        executor.setQueueCapacity(80); // (MaxPoolSize - CorePoolSize) * 2
         executor.setThreadNamePrefix("email-");
         executor.setWaitForTasksToCompleteOnShutdown(WAIT_TASK_COMPLETE);
         executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);

--- a/src/main/java/dynamicquad/agilehub/global/config/AsyncConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package dynamicquad.agilehub.global.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -22,8 +23,11 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("email-");
         executor.setWaitForTasksToCompleteOnShutdown(WAIT_TASK_COMPLETE);
         executor.setAwaitTerminationSeconds(AWAIT_TERMINATION_SECONDS);
+        // 거부 정책 설정
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+
         executor.initialize();
-        
+
         return executor;
     }
 }

--- a/src/main/java/dynamicquad/agilehub/global/config/DefaultSESConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/DefaultSESConfig.java
@@ -1,0 +1,28 @@
+package dynamicquad.agilehub.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DefaultSESConfig {
+    @Value("${aws.ses.accessKey}")
+    private String accessKey;
+
+    @Value("${aws.ses.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public AmazonSimpleEmailService amazonSimpleEmailService() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonSimpleEmailServiceClientBuilder.standard()
+            .withRegion(Regions.AP_NORTHEAST_2)
+            .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .build();
+    }
+}

--- a/src/main/java/dynamicquad/agilehub/global/config/DefaultSESConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/DefaultSESConfig.java
@@ -1,5 +1,6 @@
 package dynamicquad.agilehub.global.config;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
@@ -23,6 +24,10 @@ public class DefaultSESConfig {
         return AmazonSimpleEmailServiceClientBuilder.standard()
             .withRegion(Regions.AP_NORTHEAST_2)
             .withCredentials(new AWSStaticCredentialsProvider(credentials))
+            .withClientConfiguration(new ClientConfiguration()
+                .withConnectionTimeout(3000)
+                .withSocketTimeout(5000)
+                .withRequestTimeout(10000))
             .build();
     }
 }

--- a/src/main/java/dynamicquad/agilehub/global/config/TemplateConfig.java
+++ b/src/main/java/dynamicquad/agilehub/global/config/TemplateConfig.java
@@ -1,0 +1,18 @@
+package dynamicquad.agilehub.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+import org.thymeleaf.spring6.templateresolver.SpringResourceTemplateResolver;
+
+@Configuration
+public class TemplateConfig {
+    @Bean
+    public TemplateEngine htmlTemplateEngine(SpringResourceTemplateResolver springResourceTemplateResolver) {
+        TemplateEngine templateEngine = new SpringTemplateEngine();
+        templateEngine.addTemplateResolver(springResourceTemplateResolver);
+
+        return templateEngine;
+    }
+}

--- a/src/main/java/dynamicquad/agilehub/global/header/status/ErrorStatus.java
+++ b/src/main/java/dynamicquad/agilehub/global/header/status/ErrorStatus.java
@@ -60,10 +60,13 @@ public enum ErrorStatus implements BaseStatus {
     // Email Error
     EMAIL_NOT_SENT(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_5001", "이메일이 정상적으로 송신되지 않았습니다."),
     INVITE_CODE_NOT_EXIST(HttpStatus.BAD_REQUEST, "EMAIL_4001", "초대 코드를 찾을 수 없습니다."),
+    ALREADY_INVITATION(HttpStatus.BAD_REQUEST, "EMAIL_4002", "이미 진행 중인 초대가 있습니다"),
+    EMAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "EMAIL_4003", "이메일 서비스에 문제가 발생했습니다. 나중에 다시 시도해주세요."),
 
     // Optimistic Lock Exception
     OPTIMISTIC_LOCK_EXCEPTION(HttpStatus.LOCKED, "LOCK_4000", "다른 사용자가 이미 수정했습니다. 새로 고침 후 다시 시도해주세요."),
     OPTIMISTIC_LOCK_EXCEPTION_ISSUE_NUMBER(HttpStatus.LOCKED, "LOCK_4001", "이슈 번호 생성 실패. 다시 시도해주세요.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/dynamicquad/agilehub/global/util/RandomStringUtil.java
+++ b/src/main/java/dynamicquad/agilehub/global/util/RandomStringUtil.java
@@ -29,4 +29,8 @@ public class RandomStringUtil {
         return sb.toString();
     }
 
+    public static String generateUUID() {
+        return java.util.UUID.randomUUID().toString();
+    }
+
 }

--- a/src/main/java/dynamicquad/agilehub/global/util/RandomStringUtil.java
+++ b/src/main/java/dynamicquad/agilehub/global/util/RandomStringUtil.java
@@ -1,7 +1,10 @@
 package dynamicquad.agilehub.global.util;
 
+import java.nio.ByteBuffer;
 import java.security.SecureRandom;
+import java.util.Base64;
 import java.util.Random;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -12,6 +15,7 @@ public class RandomStringUtil {
     private static final String CHAR_SPECIAL = "!@#$%^&*";
 
     private static final String ALL_CHARS = CHAR_UPPERCASE + CHAR_LOWERCASE + CHAR_DIGITS + CHAR_SPECIAL;
+
 
     private RandomStringUtil() {
     }
@@ -32,5 +36,23 @@ public class RandomStringUtil {
     public static String generateUUID() {
         return java.util.UUID.randomUUID().toString();
     }
+
+    public static String uuidToBase64(String str) {
+        UUID uuid = UUID.fromString(str);
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bb.array());
+    }
+
+    public static String base64ToUUID(String str) {
+        byte[] bytes = Base64.getDecoder().decode(str);
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        UUID uuid = new UUID(bb.getLong(), bb.getLong());
+
+        return uuid.toString();
+    }
+
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,10 @@ aws:
     directory: /images
     workingDirectory:
       issue: issue
+  ses:
+    accessKey: ${AWS_SES_ACCESS_KEY}
+    secretKey: ${AWS_SES_SECRET_KEY}
+    from: ${AWS_SES_FROM}
 
 
 openai:

--- a/src/main/resources/templates/invite.html
+++ b/src/main/resources/templates/invite.html
@@ -123,12 +123,12 @@
     <p class="text-gray-700 mb-6" style="font-family: monospace">
         <b>관리자 및 팀과 함께 작업 계획 및 이슈 추적을 시작합니다</b> <br> <b>작업을 공유하고 팀이 무엇을 하고 있는지 볼 수 있습니다</b>
     </p>
-    <button class="w-full"><a th:href="@{https://www.agilehub.store/projects/invite(inviteCode=${inviteCode})}">Accept
+    <button class="w-full"><a th:href="@{http://www.agilehub.info/projects/invite(inviteCode=${inviteCode})}">Accept
         Invite</a>
     </button>
     <div class="mt-6 text-sm">
         <p class="text-gray-800 mb-2">
-            <a class="text-blue-600 hover:underline ml-1" href="https://www.agilehub.store/">
+            <a class="text-blue-600 hover:underline ml-1" href="http://www.agilehub.info/">
                 Learn more</a>
         </p>
     </div>

--- a/src/test/java/dynamicquad/agilehub/email/AmazonSESServiceTest.java
+++ b/src/test/java/dynamicquad/agilehub/email/AmazonSESServiceTest.java
@@ -1,0 +1,26 @@
+package dynamicquad.agilehub.email;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class AmazonSESServiceTest {
+    @Autowired
+    private AmazonSESService amazonSESService;
+
+    @Test
+    @DisplayName("Amazon SES를 이용한 이메일 발송 테스트")
+    void sendEmailTest() {
+        // given
+        String subject = "테스트 이메일 발송";
+        String to = "evobusiness99@gmail.com";
+        Map<String, Object> variables = Map.of("projectName", "테스트 프로젝트", "inviteCode", "123456");
+
+        amazonSESService.sendEmail(subject, variables, to);
+    }
+}

--- a/src/test/java/dynamicquad/agilehub/global/util/RandomStringUtilTest.java
+++ b/src/test/java/dynamicquad/agilehub/global/util/RandomStringUtilTest.java
@@ -1,0 +1,85 @@
+package dynamicquad.agilehub.global.util;
+
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+class RandomStringUtilTest {
+    // SecureRandom 32자와 UUID.randomUUID() 성능 비교
+
+    private static final int ITERATIONS = 1_000_000;
+    private static final SecureRandom secureRandom = new SecureRandom();
+    private static final String CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+    public static void main(String[] args) {
+        // Test different lengths for SecureRandom
+        int[] lengths = {16, 32, 36, 64};  // 36은 UUID 길이와 동일
+
+        for (int length : lengths) {
+            System.out.println("\nTesting with length: " + length);
+
+            // Test generation time
+            long startTime = System.currentTimeMillis();
+            List<String> secureRandomTokens = generateSecureRandomTokens(length);
+            long secureRandomTime = System.currentTimeMillis() - startTime;
+
+            startTime = System.currentTimeMillis();
+            List<String> uuidTokens = generateUuidTokens();
+            long uuidTime = System.currentTimeMillis() - startTime;
+
+            // Test collision rate
+            int secureRandomCollisions = checkCollisions(secureRandomTokens);
+            int uuidCollisions = checkCollisions(uuidTokens);
+
+            // Calculate memory usage (approximate)
+            long secureRandomMemory = calculateMemoryUsage(secureRandomTokens);
+            long uuidMemory = calculateMemoryUsage(uuidTokens);
+
+            // Print results
+            System.out.println("SecureRandom Performance:");
+            System.out.println("  Generation time: " + secureRandomTime + "ms");
+            System.out.println("  Collisions: " + secureRandomCollisions);
+            System.out.println("  Memory usage: " + secureRandomMemory + " bytes");
+
+            System.out.println("UUID Performance:");
+            System.out.println("  Generation time: " + uuidTime + "ms");
+            System.out.println("  Collisions: " + uuidCollisions);
+            System.out.println("  Memory usage: " + uuidMemory + " bytes");
+        }
+    }
+
+    private static List<String> generateSecureRandomTokens(int length) {
+        List<String> tokens = new ArrayList<>(ITERATIONS);
+        for (int i = 0; i < ITERATIONS; i++) {
+            StringBuilder token = new StringBuilder(length);
+            for (int j = 0; j < length; j++) {
+                token.append(CHARS.charAt(secureRandom.nextInt(CHARS.length())));
+            }
+            tokens.add(token.toString());
+        }
+        return tokens;
+    }
+
+    private static List<String> generateUuidTokens() {
+        List<String> tokens = new ArrayList<>(ITERATIONS);
+        for (int i = 0; i < ITERATIONS; i++) {
+            tokens.add(UUID.randomUUID().toString());
+        }
+        return tokens;
+    }
+
+    private static int checkCollisions(List<String> tokens) {
+        Set<String> uniqueTokens = new HashSet<>(tokens);
+        return tokens.size() - uniqueTokens.size();
+    }
+
+    private static long calculateMemoryUsage(List<String> tokens) {
+        // Rough estimation of memory usage
+        return tokens.get(0).length() * Character.BYTES * (long) tokens.size();
+    }
+
+
+}


### PR DESCRIPTION
## 📄 Summary

> 고려했던 것
1. 이메일을 **단건처리할지**, 대량 발송 처리할지
2. 초대 토큰 생성 방식 (JWT vs **랜덤 난수**) 
3. 초대토큰 생성은 뭘로 할지 (**UUID.randomUUID** vs SecureRandom)
4. 어떤 SMTP 릴레이 서비스를 사용할지 (Gmail SMTP vs **AWS SES** vs SendGrid)
5. 토큰은 어디에 저장할지 (DBMS vs **NoSQL**, **Redis** vs MongoDB)
6. Redis 용량 줄이기 위해 UUID 키 Base64url로 인코딩 
7. ThreadPoolTaskExecutor 설정 (max, core, queue, 거부정책)
8. SMTP 외부 서비스 장애가 발생했을 때, 리드,커넥션 타임아웃 설정 예외 발생시 재시도 정책 및 redis에 상태 관리로 분산환경에서 같은 이메일에 대해 재요청 하는 것을 막음,) 